### PR TITLE
fix animation timing calculation

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,10 @@ async def animation(screen, ball):
     current_time = 0
     while True:
         last_time, current_time = current_time, time.time()
-        await asyncio.sleep(1 / FPS - (current_time - last_time))  # tick
+        # call usually takes  a bit longer than ideal for framerate, so subtract from next wait
+        # sleeptime = 1/FPS - delayed = 1/FPS - (now-last-1/FPS)
+        # also limit max delay to avoid issues with asyncio.sleep() returning immediately for negative values
+        await asyncio.sleep(min(1 / FPS - (current_time - last_time - 1 / FPS), 1 / FPS))  # tick
         ball.move()
         screen.fill(black)
         ball.draw(screen)


### PR DESCRIPTION
Thanks for your code, it helped me a lot when trying to create some simple pygame code. And sorry for waking up the repo after nine years of slumber, but I ran into a hidden issue with the animation code that drove me nuts. 
(And yes, possibly the behavior has changed since the time you wrote this code, as I'm running it with Python 3.12 now. And obviously, being a timing issue, it might present itself differently or not at all on another system... )

In its current state, I found the animation being updated twice in short succession. That's probably not directly noticeable at 100 FPS and an example animation which has no reference for the expected outcome. When building upon your example I wanted to cycle between two frames at ~1FPS, and here the issue is obvious: only one frame is visible, when looking intensely I noticed the other frame briefly flashing for some fractions of a second.

With some logging (see `debug` branch in my fork) it looks like this:
```
DEBUG:__main__:animation called after 1735800205.727915, next sleep is -1735800205.227915
DEBUG:__main__:animation called after 0.004025, next sleep is 0.495975
DEBUG:__main__:animation called after 0.503247, next sleep is -0.003247
DEBUG:__main__:animation called after 0.009043, next sleep is 0.490957
DEBUG:__main__:animation called after 0.494076, next sleep is 0.005924
DEBUG:__main__:animation called after 0.011459, next sleep is 0.488541
DEBUG:__main__:animation called after 0.491842, next sleep is 0.008158
DEBUG:__main__:animation called after 0.013224, next sleep is 0.486776
DEBUG:__main__:animation called after 0.490121, next sleep is 0.009879
DEBUG:__main__:animation called after 0.013008, next sleep is 0.486992
DEBUG:__main__:animation called after 0.490714, next sleep is 0.009286
...
```
The initial value of `current_time = 0` causes the first sleep to have a negative parameter. And this is handled the [same as  documented for a call value of 0](https://docs.python.org/3/library/asyncio-task.html#sleeping) by providing an opportunity for other code to run and then return where it left off - without any actual waiting.

The second pass finds a very short interval since the last run, so the calculation works as intended and issues a wait order for the remaining time of the current interval.

The third pass now finds an interval slightly longer than the intended frame period, and therefore the calculation yields a negative sleep time again (goto second pass...)

I assume your intention was to avoid accumulating clock skew. If the loop runs only once per frame, the time difference is usually a little larger than the intended period and only the difference from the intended value should be subtracted from the next sleep:
`sleeptime = 1 / FPS - (current_time - last_time - 1 / FPS)`

It's still necessary to catch overly large or small intervals, I decided to do so by limiting the sleep time maximum to the intended frame interval length: `sleeptime = min(sleeptime, 1/FPS)`
If the cycle was somehow too short, the next sleep would be overly long. This is caught directly.
If the cycle was too long (by some delay, or the initial value), the next sleep would be too short or negative. This is caught indirectly in the next cycle.
Of course you could handle these cases explicitly, but that would require more comparisons to be done every cycle and I decided against it. 

With the changed code, the log looks as follows:
```
DEBUG:__main__:animation called after 1735799905.737859, next sleep is -1735799904.737859
DEBUG:__main__:animation called after 0.006165, next sleep is 0.500000
DEBUG:__main__:animation called after 0.509775, next sleep is 0.490225
DEBUG:__main__:animation called after 0.494173, next sleep is 0.500000
DEBUG:__main__:animation called after 0.503532, next sleep is 0.496468
DEBUG:__main__:animation called after 0.499626, next sleep is 0.500000
DEBUG:__main__:animation called after 0.503721, next sleep is 0.496279
DEBUG:__main__:animation called after 0.500419, next sleep is 0.499581
DEBUG:__main__:animation called after 0.502952, next sleep is 0.497048
...
```

It also works as intended at 100 FPS
```
DEBUG:__main__:animation called after 1735799799.393995, next sleep is -1735799799.373995
DEBUG:__main__:animation called after 0.003778, next sleep is 0.010000
DEBUG:__main__:animation called after 0.018114, next sleep is 0.001886
DEBUG:__main__:animation called after 0.010582, next sleep is 0.009418
DEBUG:__main__:animation called after 0.013404, next sleep is 0.006596
DEBUG:__main__:animation called after 0.010252, next sleep is 0.009748
DEBUG:__main__:animation called after 0.012867, next sleep is 0.007133
DEBUG:__main__:animation called after 0.011124, next sleep is 0.008876
DEBUG:__main__:animation called after 0.012407, next sleep is 0.007593
DEBUG:__main__:animation called after 0.010481, next sleep is 0.009519
DEBUG:__main__:animation called after 0.012511, next sleep is 0.007489
DEBUG:__main__:animation called after 0.010250, next sleep is 0.009750
...
```